### PR TITLE
Use concatMap for lazy semantics

### DIFF
--- a/rx.js
+++ b/rx.js
@@ -13,8 +13,7 @@ const Rx = require('rxjs/Rx');
 const files = Rx.Observable.from(filenameArray);
 
 const fileContents = files
-    .map(file => promiseOfFileContents(file))
-    .mergeAll();
+    .concatMap(file => promiseOfFileContents(file));
 
 const oneFile = fileContents.take(1);
 oneFile.subscribe(console.log.bind(console));


### PR DESCRIPTION
Hi Hugo!

Many Rx operators apparently aren't lazy, but `concatMap` is. See [this issue](https://github.com/Reactive-Extensions/RxJS/issues/503) for an explanation.

Happy hacking!

-- Steen
